### PR TITLE
fix: Ensure Protobuf_FOUND is only defined if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,11 +160,13 @@ if(NuHepMC_CPPUtils_PYTHON_ENABLED)
 endif()
 
 if(NuHepMC_CPPUtils_BUILTIN_HEPMC3)
-  find_package(Protobuf 2.4)
 
   set(NuHepMC_CPPUtils_BUILTIN_HEPMC3_ENABLE_PROTOBUFIO OFF)
-  if(Protobuf_FOUND AND NuHepMC_CPPUtils_PROTOBUF_INTERFACE)
-    set(NuHepMC_CPPUtils_BUILTIN_HEPMC3_ENABLE_PROTOBUFIO ON)
+  if(NuHepMC_CPPUtils_PROTOBUF_INTERFACE)
+    find_package(Protobuf 2.4)
+    if(Protobuf_FOUND)
+        set(NuHepMC_CPPUtils_BUILTIN_HEPMC3_ENABLE_PROTOBUFIO ON)
+    endif()
   endif()
 
   CPMAddPackage(


### PR DESCRIPTION
This should resolve the issue with HepMC3 and protobufIO