### PR TITLE
More verbose error

### DIFF
--- a/src/NuHepMC/make_writer.cxx
+++ b/src/NuHepMC/make_writer.cxx
@@ -61,9 +61,9 @@ int ParseExtension(std::string const &name) {
     return kBZip2;
   }
   throw NuHepMC::UnknownFilenameExtension()
-      << "Parsed extension: \"" << ext << "\" from filename: \"" << name
-      << "\", could not automatically determine HepMC3::Writer concrete "
-         "type";
+  << "Parsed extension: \"" << ext << "\" from filename: \"" << name
+  << "\"\nSupported extensions: hepmc3, hepmc, proto, pb, gz, lzma, bz2\n"
+  << "Could not automatically determine HepMC3::Writer type";
 }
 
 template <bxz::Compression C>


### PR DESCRIPTION
Can do this better but in NEUT newbie can easily run blarb.root and get this error.
So having actual extension in output would help.